### PR TITLE
Adopt Markdown syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ Advanced C/C++ library(ACL) for UNIX-like OS and WIN32 OS, including sync/async/
 * unit test framework
 
 ### Contact
-Website: http://www.iteye.com
-Download: https://sourceforge.net/projects/acl
-QQ group: 242722074
+- Website: http://www.iteye.com
+- Download: https://sourceforge.net/projects/acl
+- QQ group: 242722074

--- a/README.md
+++ b/README.md
@@ -1,25 +1,26 @@
-acl -- one advanced C/C++ lib for UNIX and WINDOWS
-===
-Description:<br>
-Advanced C/C++ library(ACL) for UNIX-like OS and WIN32 OS, including sync/async/ssl iostream for net/file, thread pool, process pool, db pool, server framework, event, memory, string, array/hash/ring/list, xml and json parser, http/smtp/icmp protocol, SSL/TLS, C unit test, etc<br>
-<br>
-Features:<br>
-data structure: array/htable/ring/stack/avl<br>
-socket/file stream(sync stream and async stream)<br>
-http/icmp/smtp protocol<br>
-json/xml/mime/base64/qp/uucode, etc parse lib<br>
-thread/process pool<br>
-mysql/sqlite connection pool<br>
-event(select, poll, iocp, epoll, kqueue, devpoll, win32 message)<br>
-server framework(multi-process, multi-threads, aio, trigger, udp)<br>
-HttpServlet for C++; http client/server lib<br>
-log/configure lib<br>
-file queue<br>
-handler socket/memcached/beanstalkd client<br>
-zlib/iconv wrapper<br>
-session manager<br>
-unit test framework<br>
+## acl -- one advanced C/C++ lib for UNIX and WINDOWS
 
-website: <a href=http://www.iteye.com/ target=_blank>http://www.iteye.com/</a><br>
-download: <a href=https://sourceforge.net/projects/acl/ target=_blank>https://sourceforge.net/projects/acl/</a><br>
-qq group: 242722074<br>
+### Description
+Advanced C/C++ library(ACL) for UNIX-like OS and WIN32 OS, including sync/async/ssl iostream for net/file, thread pool, process pool, db pool, server framework, event, memory, string, array/hash/ring/list, xml and json parser, http/smtp/icmp protocol, SSL/TLS, C unit test, etc
+
+### Features
+* data structure: array/htable/ring/stack/avl
+* socket/file stream(sync stream and async stream)
+* http/icmp/smtp protocol
+* json/xml/mime/base64/qp/uucode, etc parse lib
+* thread/process pool
+* mysql/sqlite connection pool
+* event(select, poll, iocp, epoll, kqueue, devpoll, win32 message)
+* server framework(multi-process, multi-threads, aio, trigger, udp)
+* HttpServlet for C++; http client/server lib
+* log/configure lib
+* file queue
+* handler socket/memcached/beanstalkd client
+* zlib/iconv wrapper
+* session manager
+* unit test framework
+
+### Contact
+Website: http://www.iteye.com
+Download: https://sourceforge.net/projects/acl
+QQ group: 242722074


### PR DESCRIPTION
I manually convert HTML to Markdown since I think It's more readable for both users (the rendered output) and developers (the raw text).
