### PR TITLE
add xmake.lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,7 @@ lib_acl_cpp/src/acl_stdafx.hpp.gch
 lib_protocol/Debug/
 lib_protocol/debug/
 lib_rpc/Debug/
+
+# xmake
+.xmake
+.DS_Store

--- a/app/master/daemon/xmake.lua
+++ b/app/master/daemon/xmake.lua
@@ -1,0 +1,17 @@
+target("master_daemon")
+
+    -- set kind: binary
+    set_kind("binary")
+
+    -- set default: disable
+    set_default(false)
+
+    -- add deps: acl_cpp, acl
+    add_deps("acl_cpp", "acl")
+
+    -- add source files
+    add_files("**.cpp")
+
+    -- add include directories
+    add_includedirs(".")
+

--- a/lib_acl/src/stdlib/common/avl.c
+++ b/lib_acl/src/stdlib/common/avl.c
@@ -631,7 +631,7 @@ avl_insert_here(
 void
 avl_add(avl_tree_t *tree, void *new_node)
 {
-	avl_index_t where;
+	avl_index_t where = 0;
 
 	/*
 	 * This is unfortunate.  We want to call panic() here, even for

--- a/lib_acl/xmake.lua
+++ b/lib_acl/xmake.lua
@@ -1,0 +1,18 @@
+-- define target: acl
+target("acl")
+
+    -- set kind: static/shared
+    set_kind("$(kind)")
+
+    -- add source files
+    add_files("src/**.c|*/bak/*.c")
+
+    -- add include directories
+    add_includedirs(".", "include")
+
+    -- add headers
+    add_headers("include/(**.h)")
+    set_headerdir("$(buildir)/include/acl")
+
+    -- add defines
+    add_defines("USE_REUSEPORT")

--- a/lib_acl_cpp/src/http/websocket.cpp
+++ b/lib_acl_cpp/src/http/websocket.cpp
@@ -281,6 +281,7 @@ static bool is_big_endian(void)
 		return true;
 }
 
+#ifndef swap64
 #define swap64(val) (((val) >> 56) | \
 	(((val) & 0x00ff000000000000ll) >> 40) | \
 	(((val) & 0x0000ff0000000000ll) >> 24) | \
@@ -289,6 +290,7 @@ static bool is_big_endian(void)
 	(((val) & 0x0000000000ff0000ll) << 24) | \
 	(((val) & 0x000000000000ff00ll) << 40) | \
 	(((val) << 56)))
+#endif
 
 #define	hton64(val) is_big_endian() ? val : swap64(val)
 #define	ntoh64(val) hton64(val)

--- a/lib_acl_cpp/xmake.lua
+++ b/lib_acl_cpp/xmake.lua
@@ -1,0 +1,35 @@
+-- define target: acl_cpp
+target("acl_cpp")
+
+    -- set kind: static/shared
+    set_kind("$(kind)")
+
+    -- add deps: protocol, acl
+    add_deps("protocol", "acl")
+
+    -- add source files
+    add_files("src/**.cpp|aliyun/**.cpp")
+
+    -- add include directories
+    add_includedirs("$(projectdir)/include")
+    add_includedirs("$(projectdir)/include/zlib")
+    add_includedirs("$(projectdir)/include/mysql")
+    add_includedirs("$(projectdir)/include/pgsql")
+    add_includedirs("$(projectdir)/include/sqlite")
+    add_includedirs("src", "include")
+
+    -- add headers
+    add_headers("include/(**.h)", "include/(**.hpp)", "include/(**.ipp)")
+    set_headerdir("$(buildir)/include/acl_cpp")
+
+    -- set precompile header
+    set_pcxxheader("src/acl_stdafx.hpp")
+
+    -- add defines and links
+    add_defines("HAS_MYSQL_DLL", "HAS_PGSQL_DLL", "HAS_SQLITE_DLL", "HAS_POLARSSL_DLL")
+    if is_plat("windows") then
+        add_defines("HAS_ZLIB_DLL", "USE_WIN_ICONV")
+    else
+        add_links("iconv")
+    end
+

--- a/lib_fiber/c/src/event_epoll.c
+++ b/lib_fiber/c/src/event_epoll.c
@@ -1,5 +1,7 @@
 #include "stdafx.h"
+#ifndef __USE_GNU
 #define __USE_GNU
+#endif
 #include <dlfcn.h>
 #include <sys/epoll.h>
 #include "fiber.h"

--- a/lib_fiber/c/src/fiber.c
+++ b/lib_fiber/c/src/fiber.c
@@ -1,6 +1,9 @@
 #include "stdafx.h"
+#ifndef __USE_GNU
 #define __USE_GNU
+#endif
 #include <dlfcn.h>
+#include <signal.h>
 
 #ifdef USE_VALGRIND
 #include <valgrind/valgrind.h>
@@ -74,8 +77,8 @@ static size_t stack_size(size_t size)
 
 static void *stack_alloc(size_t size)
 {
-	char  *ptr;
 	int    ret;
+	char  *ptr = NULL;
 	size_t pgsz = page_size();
 
 	size = stack_size(size);
@@ -122,6 +125,14 @@ static void stack_free(void *ptr)
 }
 
 #endif
+
+static void *stack_calloc(size_t size)
+{
+	void* ptr = stack_alloc(size);
+    if (ptr)
+        memset(ptr, 0, size);
+    return ptr;
+}
 
 /****************************************************************************/
 

--- a/lib_fiber/c/src/hook_io.c
+++ b/lib_fiber/c/src/hook_io.c
@@ -8,7 +8,9 @@
 #include <unistd.h>
 #include <sys/sendfile.h>
 
+#ifndef __USE_GNU
 #define __USE_GNU
+#endif
 #include <dlfcn.h>
 #include <sys/stat.h>
 #include "fiber.h"

--- a/lib_fiber/c/src/hook_net.c
+++ b/lib_fiber/c/src/hook_net.c
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include "stdafx.h"
 #include <dlfcn.h>
 #include <poll.h>

--- a/lib_fiber/c/xmake.lua
+++ b/lib_fiber/c/xmake.lua
@@ -1,0 +1,21 @@
+-- define target: fiber
+target("fiber")
+
+    -- set kind: static/shared
+    set_kind("$(kind)")
+
+    -- add deps: acl
+    add_deps("acl")
+
+    -- add source files
+    add_files("src/**.c")
+
+    -- add include directories
+    add_includedirs("src", "include", "../../lib_acl/src/master")
+
+    -- add headers
+    add_headers("include/(**.h)")
+    set_headerdir("$(buildir)/include/fiber")
+
+
+

--- a/lib_fiber/cpp/xmake.lua
+++ b/lib_fiber/cpp/xmake.lua
@@ -1,0 +1,21 @@
+-- define target: fiber_cpp
+target("fiber_cpp")
+
+    -- set kind: static/shared
+    set_kind("$(kind)")
+
+    -- add deps: fiber, acl
+    add_deps("fiber", "acl_cpp", "acl")
+
+    -- add source files
+    add_files("src/**.cpp")
+
+    -- add include directories
+    add_includedirs("src", "include")
+
+    -- add headers
+    add_headers("include/(**.h)", "include/(**.hpp)")
+    set_headerdir("$(buildir)/include/fiber_cpp")
+
+
+

--- a/lib_protocol/xmake.lua
+++ b/lib_protocol/xmake.lua
@@ -1,0 +1,21 @@
+-- define target: protocol
+target("protocol")
+
+    -- set kind: static/shared
+    set_kind("$(kind)")
+
+    -- add deps: acl
+    add_deps("acl")
+
+    -- add source files
+    add_files("src/**.c")
+
+    -- add include directories
+    add_includedirs("src", "include")
+
+    -- add headers
+    add_headers("include/(**.h)")
+    set_headerdir("$(buildir)/include/protocol")
+
+
+

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,138 @@
+-- project
+set_project("acl")
+
+-- version
+set_version("3.3.1.rc1")
+set_xmakever("2.1.6")
+
+-- set warning all as error
+set_warnings("all", "error")
+
+-- set the object files directory
+set_objectdir("$(buildir)/$(mode)/$(arch)/.objs")
+set_targetdir("$(buildir)/$(mode)/$(arch)")
+
+-- the debug or release mode
+if is_mode("debug") then
+    
+    -- enable the debug symbols
+    set_symbols("debug")
+
+    -- disable optimization
+    set_optimize("none")
+
+    -- link libcmtd.lib
+    if is_plat("windows") then 
+        add_cxflags("-MTd") 
+    end
+
+elseif is_mode("release") then
+
+    -- set the symbols visibility: hidden
+    if not is_kind("shared") then
+        set_symbols("hidden")
+    end
+
+    -- strip all symbols
+    set_strip("all")
+
+    -- enable fastest optimization
+    set_optimize("fastest")
+
+    -- link libcmt.lib
+    if is_plat("windows") then 
+        add_cxflags("-MT") 
+    end
+end
+
+-- add common flags and macros
+add_defines("ACL_WRITEABLE_CHECK", "ACL_PREPARE_COMPILE")
+
+-- for the windows platform (msvc)
+if is_plat("windows") then 
+    add_cxxflags("-EHsc")
+    add_ldflags("-nodefaultlib:\"msvcrt.lib\"")
+	add_links("ws2_32", "IPHlpApi", "kernel32", "user32", "gdi32")
+end
+
+-- for the android platform
+if is_plat("android") then
+    add_defines("ANDROID")
+end
+
+-- for macosx
+if is_plat("macosx") then
+    add_defines("MACOSX")
+    add_links("pthread", "z")
+end
+
+-- for linux
+if is_plat("linux") then
+    add_defines("LINUX2")
+    add_links("pthread", "z", "dl")
+end
+
+-- for mingw
+if is_plat("mingw") then
+    add_defines("LINUX2", "MINGW")
+end
+
+-- for freebsd
+if is_plat("freebsd") then
+    add_defines("FREEBSD")
+end
+
+-- for Solaris (x86)
+if is_plat("sunos5") then
+    add_defines("SUNOS5")
+end
+
+-- for all non-windows platforms
+if not is_plat("windows") then
+    add_cflags("-Wshadow", "-Wpointer-arith", "-Waggregate-return", "-Wmissing-prototypes", "-Wno-long-long", "-Wuninitialized", "-Wstrict-prototypes")
+    add_defines("_REENTRANT", "_USE_FAST_MACRO", "_POSIX_PTHREAD_SEMANTICS", "_GNU_SOURCE=1")
+end
+
+-- include project sources
+includes("app/**/xmake.lua", "lib_acl", "lib_protocol", "lib_acl_cpp") 
+if is_plat("linux") then
+    includes("lib_fiber/c", "lib_fiber/cpp")
+end
+
+-- Build project (static library/release by default)
+--
+-- linux/macosx/windows:
+-- $ xmake
+--
+-- iphoneos:
+-- $ xmake f -p iphoneos
+-- $ xmake
+--
+-- android:
+-- $ xmake f -p android --ndk=/home/xxx/android-ndk-r10e
+-- $ xmake
+--
+-- freebsd:
+-- $ xmake f -p freebsd
+-- $ xmake
+--
+-- mingw:
+-- $ xmake f -p mingw
+-- $ xmake
+--
+-- Build for share library with debug mode
+--
+-- $ xmake f -k shared -m debug; xmake
+--
+-- Configuration 
+--
+-- $ xmake f -p [windows|linux|iphoneos|android|macosx|freebsd|sunos5|cross] -m [debug|release] -a [x86|x64|x86_64|armv7|arm64|armv8-a] -k [static|shared]
+--
+-- Generate IDE project
+--
+-- $ xmake project -k vs2008
+-- $ xmake project -k vs2017 -m "debug,release"
+-- $ xmake project -k makefile
+--
+-- If you want to known more usage about xmake, please see: http://xmake.io/#/home?id=configuration
+--


### PR DESCRIPTION
集成xmake，实现跨平台一致性构建，目前集成了以下一些模块的构建：

- [x] lib_acl
- [x] lib_acl_cpp
- [x] lib_protocol
- [x] lib_fiber
- [x] lib_fiber_cpp
- [x] app
  - [x] master
    - [x] daemon

具体构建方式，在跟目录`./xmake.lua`底部注释有详细说明，大致的构建用法：

在`linux/macosx/windows`等平台默认构建（静态库/Release）

```console
$ xmake
```

构建iphoneos平台目标（静态库/Release）

```console
$ xmake f -p iphoneos
$ xmake
```

构建android平台目标（静态库/Release）

```console
$ xmake f -p android --ndk=/home/xxx/android-ndk-r10e
$ xmake
```

在msys上构建mingw平台目标（静态库/Release）

```console
$ xmake f -p mingw
$ xmake
```

其他平台或者交叉编译：

```console
$ xmake f -p freebsd
$ xmake

$ xmake f -p sunos5
$ xmake

$ xmake f -p cross --sdk=/usr/local/arm-xxx-gcc/ [--toolchains=/sdk/bin] [--cross=arm-linux-]
$ xmake
```

更详细的交叉编译说明见：[交叉编译文档](http://xmake.io/#/zh/?id=%E4%BA%A4%E5%8F%89%E7%BC%96%E8%AF%91)

编译动态库，并且切换到debug模式

```console
$ xmake f -k shared -m debug
$ xmake
```

其他一些常用配置参数：

```console
$ xmake f -p [windows|linux|iphoneos|android|macosx|freebsd|sunos5|cross] -m [debug|release] -a [x86|x64|x86_64|armv7|arm64|armv8-a] -k [static|shared]
```

产生vs IDE工程文件 （详细用法见文档：[生成IDE工程文件](http://xmake.io/#/zh/plugins?id=%E7%94%9F%E6%88%90ide%E5%B7%A5%E7%A8%8B%E6%96%87%E4%BB%B6)）

```console
$ xmake project -k vs2008
$ xmake project -k vs2017 -m "debug,release"
$ xmake project -k makefile
```

更多关于xmake的配置和使用说明见：[xmake中文文档](http://xmake.io/#/zh/)
