### PR TITLE
add some xmake.lua for app

### DIFF
--- a/app/gid/gid_client/c/xmake.lua
+++ b/app/gid/gid_client/c/xmake.lua
@@ -1,0 +1,17 @@
+target("gid")
+
+    -- set kind: static
+    set_kind("static")
+
+    -- set default: disable
+    set_default(false)
+
+    -- add deps: acl_cpp, acl
+    add_deps("acl_cpp", "acl")
+
+    -- add source files
+    add_files("src/**.c")
+
+    -- add include directories
+    add_includedirs(".", "include")
+

--- a/app/gid/gid_server/include/service_main.h
+++ b/app/gid/gid_server/include/service_main.h
@@ -20,7 +20,7 @@ extern void service_exit(void *ctx);
  * @param stream {ACL_VSTREAM*} 客户端数据连接流
  * @param ctx {void*} 用户自定义类型指针
  */
-extern int service_main(ACL_VSTREAM *stream, void *ctx);
+extern int service_main(void* ctx, ACL_VSTREAM *stream);
 
 #ifdef	__cplusplus
 }

--- a/app/gid/gid_server/src/service_main.c
+++ b/app/gid/gid_server/src/service_main.c
@@ -134,7 +134,7 @@ void service_exit(void *ctx acl_unused)
 	gid_finish();
 }
 
-int service_main(ACL_VSTREAM *client, void *ctx acl_unused)
+int service_main(void *ctx acl_unused, ACL_VSTREAM *client)
 {
 	int   (*service)(ACL_VSTREAM*) = NULL;
 	int   ret;

--- a/app/gid/gid_server/unix/main.c
+++ b/app/gid/gid_server/unix/main.c
@@ -18,7 +18,7 @@ static void app_run(void *arg)
 	ACL_VSTREAM *client = (ACL_VSTREAM*) arg;
 
 	while (1) {
-		if (service_main(client, NULL) < 0)
+		if (service_main(NULL, client) < 0)
 			break;
 		if (__run_once)
 			break;
@@ -42,7 +42,7 @@ static ACL_VSTREAM *init(const char *filepath)
 	char  addr[] = ":7072";
 	ACL_XINETD_CFG_PARSER *cfg = NULL;
 
-	acl_init();
+	acl_lib_init();
 	/*
 	acl_debug_malloc_init(NULL, "log.txt");
 	*/
@@ -70,7 +70,7 @@ static void end(void)
 {
 	service_exit(NULL);
 	acl_myfree(var_cfg_gid_path);
-	acl_end();
+	acl_lib_end();
 }
 
 static void app_test_thrpool(const char *filepath)

--- a/app/gid/gid_server/win32/main.c
+++ b/app/gid/gid_server/win32/main.c
@@ -16,7 +16,7 @@ static void client_thread(int event_type acl_unused, void* arg)
 	
 	while (1) {
 		last = time(NULL);
-		if (service_main(client, NULL) < 0)
+		if (service_main(NULL, client) < 0)
 			break;
 		cost = time(NULL) - last;
 		if (cost >= 1)

--- a/app/gid/gid_server/xmake.lua
+++ b/app/gid/gid_server/xmake.lua
@@ -1,0 +1,22 @@
+target("gid_server")
+
+    -- set kind: binary
+    set_kind("binary")
+
+    -- set default: disable
+    set_default(false)
+
+    -- add deps: acl_cpp, acl
+    add_deps("acl_cpp", "acl")
+
+    -- add source files
+    add_files("src/**.c")
+    if is_plat("windows") then
+        add_files("win32/*.c")
+    else
+        add_files("unix/*.c")
+    end
+
+    -- add include directories
+    add_includedirs(".", "include")
+

--- a/app/gson/xmake.lua
+++ b/app/gson/xmake.lua
@@ -1,0 +1,17 @@
+target("gson")
+
+    -- set kind: binary
+    set_kind("binary")
+
+    -- set default: disable
+    set_default(false)
+
+    -- add deps: acl_cpp, acl
+    add_deps("acl_cpp", "acl")
+
+    -- add source files
+    add_files("src/**.cpp")
+
+    -- add include directories
+    add_includedirs(".", "include")
+

--- a/app/http_logger/xmake.lua
+++ b/app/http_logger/xmake.lua
@@ -1,0 +1,17 @@
+target("http_logger")
+
+    -- set kind: binary
+    set_kind("binary")
+
+    -- set default: disable
+    set_default(false)
+
+    -- add deps: acl_cpp, acl
+    add_deps("acl_cpp", "acl")
+
+    -- add source files
+    add_files("**.cpp")
+
+    -- add include directories
+    add_includedirs(".")
+

--- a/app/iconv/xmake.lua
+++ b/app/iconv/xmake.lua
@@ -1,0 +1,17 @@
+target("iconv")
+
+    -- set kind: binary
+    set_kind("binary")
+
+    -- set default: disable
+    set_default(false)
+
+    -- add deps: acl_cpp, acl
+    add_deps("acl_cpp", "acl")
+
+    -- add source files
+    add_files("**.cpp")
+
+    -- add include directories
+    add_includedirs(".")
+

--- a/app/master/tools/master_ctl/xmake.lua
+++ b/app/master/tools/master_ctl/xmake.lua
@@ -1,0 +1,18 @@
+target("master_ctl")
+
+    -- set kind: binary
+    set_kind("binary")
+
+    -- set default: disable
+    set_default(false)
+
+    -- add deps: acl_cpp, acl
+    add_deps("acl_cpp", "acl")
+
+    -- add source files
+    add_files("**.cpp")
+    add_files("../../daemon/json/*.cpp")
+
+    -- add include directories
+    add_includedirs(".", "../../daemon/json")
+

--- a/app/master/tools/master_ctld/xmake.lua
+++ b/app/master/tools/master_ctld/xmake.lua
@@ -1,0 +1,18 @@
+target("master_ctld")
+
+    -- set kind: binary
+    set_kind("binary")
+
+    -- set default: disable
+    set_default(false)
+
+    -- add deps: acl_cpp, acl
+    add_deps("acl_cpp", "acl")
+
+    -- add source files
+    add_files("**.cpp")
+    add_files("../../daemon/json/*.cpp")
+
+    -- add include directories
+    add_includedirs(".", "../../daemon/json")
+

--- a/app/wizard/xmake.lua
+++ b/app/wizard/xmake.lua
@@ -1,0 +1,17 @@
+target("wizard")
+
+    -- set kind: binary
+    set_kind("binary")
+
+    -- set default: disable
+    set_default(false)
+
+    -- add deps: acl_cpp, acl
+    add_deps("acl_cpp", "acl")
+
+    -- add source files
+    add_files("**.cpp|tmpl/**")
+
+    -- add include directories
+    add_includedirs(".")
+

--- a/app/wizard_demo/qrserver/xmake.lua
+++ b/app/wizard_demo/qrserver/xmake.lua
@@ -1,0 +1,17 @@
+target("qrserver")
+
+    -- set kind: binary
+    set_kind("binary")
+
+    -- set default: disable
+    set_default(false)
+
+    -- add deps: acl_cpp, acl
+    add_deps("acl_cpp", "acl")
+
+    -- add source files
+    add_files("**.cpp")
+
+    -- add include directories
+    add_includedirs(".")
+

--- a/xmake.lua
+++ b/xmake.lua
@@ -124,6 +124,10 @@ end
 --
 -- $ xmake f -k shared -m debug; xmake
 --
+-- Build and run app example
+--
+-- $ xmake run [gson|iconv|wizard|master_ctl|master_daemon|...]
+--
 -- Configuration 
 --
 -- $ xmake f -p [windows|linux|iphoneos|android|macosx|freebsd|sunos5|cross] -m [debug|release] -a [x86|x64|x86_64|armv7|arm64|armv8-a] -k [static|shared]


### PR DESCRIPTION
对一些app example添加xmake支持，app里面的所有example，默认是不会被构建的，需要手动指定是否编译和运行。

编译并运行某个app:

```console
$ xmake run wizard
```

仅仅编译某个app:

```console
$ xmake build wizard
```

重新编译某个app:

```console
$ xmake [-r|--rebuild] wizard
```

强制编译所有，包括所有app：

```console
$ xmake [-a|--all]
```