### PR TITLE
补充之前修改后，遗漏的提交。

### DIFF
--- a/lib_acl_cpp/src/http/http_aclient.cpp
+++ b/lib_acl_cpp/src/http/http_aclient.cpp
@@ -554,7 +554,7 @@ void http_aclient::send_request(const void* body, size_t len)
 {
 	http_method_t method = header_->get_method();
 	if (body && len > 0 && method != HTTP_METHOD_POST
-		&& method != HTTP_METHOD_PUT) {
+		&& method != HTTP_METHOD_PUT && method != HTTP_METHOD_PATCH) {
 
 		header_->set_content_length(len);
 		header_->set_method(HTTP_METHOD_POST);

--- a/lib_acl_cpp/src/http/http_request.cpp
+++ b/lib_acl_cpp/src/http/http_request.cpp
@@ -333,7 +333,7 @@ bool http_request::request(const void* data, size_t len)
 	if (data && len > 0) {
 		header_.set_content_length(len);
 
-		if (method != HTTP_METHOD_POST && method != HTTP_METHOD_PUT) {
+		if (method != HTTP_METHOD_POST && method != HTTP_METHOD_PUT && method != HTTP_METHOD_PATCH) {
 			// 在有数据体的条件下，重新设置 HTTP 请求方法
 			header_.set_method(HTTP_METHOD_POST);
 		}


### PR DESCRIPTION
之前遗漏的提交，会导致 patch 请求在发送数据时，请求头被强制设置为 POST 方法。 #162 