### PR TITLE
feature: mbedtls add multi server cert support

### DIFF
--- a/lib_acl_cpp/include/acl_cpp/stream/mbedtls_conf.hpp
+++ b/lib_acl_cpp/include/acl_cpp/stream/mbedtls_conf.hpp
@@ -45,6 +45,11 @@ public:
 	/**
 	 * @override
 	 */
+	bool append_key_cert(const char* crt_file, const char* key_file, const char* key_pass = NULL);
+
+	/**
+	 * @override
+	 */
 	bool add_cert(const char* crt_file);
 
 	/**

--- a/lib_acl_cpp/include/acl_cpp/stream/sslbase_conf.hpp
+++ b/lib_acl_cpp/include/acl_cpp/stream/sslbase_conf.hpp
@@ -38,7 +38,23 @@ public:
 	/**
 	 * 添加一个服务端/客户端自己的证书，可以多次调用本方法加载多个证书
 	 * @param crt_file {const char*} 证书文件全路径，非空
+	 * @param key_file {const char*} 密钥文件全路径，非空
+	 * @param key_pass {const char*} 密钥文件的密码，没有密钥密码可写 NULL
 	 * @return {bool} 添加证书是否成功
+	 */
+	virtual bool append_key_cert(const char* crt_file, const char* key_file, const char* key_pass = NULL)
+	{
+		(void) crt_file;
+		(void) key_file;
+		(void) key_pass;
+		return false;
+	}
+
+	/**
+	 * 添加一个服务端/客户端自己的证书，可以多次调用本方法加载多个证书
+	 * @param crt_file {const char*} 证书文件全路径，非空
+	 * @return {bool} 添加证书是否成功
+	 * @deprecated use append_key_cert
 	 */
 	virtual bool add_cert(const char* crt_file)
 	{
@@ -51,6 +67,7 @@ public:
 	 * @param key_file {const char*} 密钥文件全路径，非空
 	 * @param key_pass {const char*} 密钥文件的密码，没有密钥密码可写 NULL
 	 * @return {bool} 设置是否成功
+	 * @deprecated use append_key_cert
 	 */
 	virtual bool set_key(const char* key_file, const char* key_pass = NULL)
 	{


### PR DESCRIPTION
The mbedtls support more than one cert/key pair (eg one ECDSA, one RSA with SHA-256, one RSA with SHA-1). In case multiple certificates are adequate, preference is given to the one set by the first call to `append_key_cert` function, then second, etc.