### PR TITLE
Fix redis scan_keys

### DIFF
--- a/lib_acl_cpp/src/redis/redis_command.cpp
+++ b/lib_acl_cpp/src/redis/redis_command.cpp
@@ -789,7 +789,8 @@ int redis_command::get_strings(std::vector<const char*>& names,
 const redis_result** redis_command::scan_keys(const char* cmd, const char* key,
 	int& cursor, size_t& size, const char* pattern, const size_t* count)
 {
-	return scan_keys(cmd, key, strlen(key), cursor, size, pattern, count);
+	size_t klen = key ? strlen(key) : 0;
+	return scan_keys(cmd, key, klen, cursor, size, pattern, count);
 }
 
 const redis_result** redis_command::scan_keys(const char* cmd, const char* key,


### PR DESCRIPTION
Hello!

I think i found bug in commit [add more methos in redis_hash](https://github.com/acl-dev/acl/commit/4296c6a536655d3275e38cd9e0eea2d83574d584)

In file [redis_command.cpp](https://github.com/acl-dev/acl/blob/4296c6a536655d3275e38cd9e0eea2d83574d584/lib_acl_cpp/src/redis/redis_command.cpp#L1066-L1075) function `redis_command::scan_keys` was overloaded by parameters.

But `redis_command::scan_keys` called from [redis_key.cpp](https://github.com/acl-dev/acl/blob/b2d07d0b75eac4fa27d9b5cb924031b3bae9db44/lib_acl_cpp/src/redis/redis_key.cpp#L661-L662) with `key=NULL` and in that case result of `strlen(key)` will be an exception (access violation).

I suggest checking `key` value and calc its length correctly.

Best regards, Artamonov Evgeney.

P.S. English is not my native language, so please be kind to my mistakes.