### PR TITLE
fiber: bugfix for win32 (add_read and iocp_wait)

### DIFF
--- a/lib_fiber/c/src/event.c
+++ b/lib_fiber/c/src/event.c
@@ -115,6 +115,7 @@ long long event_get_stamp(EVENT *ev)
 int event_checkfd(EVENT *ev, FILE_EVENT *fe)
 {
 	if (getsockfamily(fe->fd) >= 0) {
+        fe->type = TYPE_SPIPE;
 		return 1;
 	}
 	if (ev->checkfd(ev, fe) == 0) {

--- a/lib_fiber/c/src/event/event_iocp.c
+++ b/lib_fiber/c/src/event/event_iocp.c
@@ -577,7 +577,7 @@ static void iocp_wait_more(EVENT_IOCP *ei, int timeout) {
         int err = acl_fiber_last_error();
 
         if (err != WAIT_TIMEOUT) {
-            msg_error("%s(%d):GetQueuedCompletionStatus error=%d, %s",
+            msg_error("%s(%d):GetQueuedCompletionStatusEx error=%d, %s",
                       __FUNCTION__, __LINE__, err,
                       last_serror());
         }


### PR DESCRIPTION
1. 初次event_add_read时类型未指定
2. 函数GetQueuedCompletionStatusEx用法不正确
