### PR TITLE
fiber: fix doze for win32

### DIFF
--- a/lib_fiber/c/src/common/doze.c
+++ b/lib_fiber/c/src/common/doze.c
@@ -5,16 +5,17 @@
 
 /* doze - sleep a while */
 
+#ifdef SYS_WIN
+void doze(unsigned delay) {
+    Sleep(delay);
+}
+#else
 void doze(unsigned delay)
 {
 	struct timeval tv;
 
 	tv.tv_sec = delay / 1000;
-#if defined(SYS_WIN)
-	tv.tv_usec = (long) (delay - tv.tv_sec * 1000) * 1000;
-#else
 	tv.tv_usec = (suseconds_t) (delay - tv.tv_sec * 1000) * 1000;
-#endif
 
 	while (select(0, (fd_set *) 0, (fd_set *) 0, (fd_set *) 0, &tv) < 0) {
 		if (acl_fiber_last_error() != FIBER_EINTR) {
@@ -22,3 +23,4 @@ void doze(unsigned delay)
 		}
 	}
 }
+#endif


### PR DESCRIPTION
在win32中不能使用select延时