### PR TITLE
fiber: bugfix recv when signal

### DIFF
--- a/lib_fiber/c/src/fiber.c
+++ b/lib_fiber/c/src/fiber.c
@@ -546,17 +546,15 @@ void acl_fiber_signal(ACL_FIBER *fiber, int signum)
 
 	fiber->status = FIBER_STATUS_READY;
 	ring_append(&__thread_fiber->ready, &fiber->me);
-
-	acl_fiber_switch();
 #else
 	fiber->status = FIBER_STATUS_READY;
 	ring_prepend(&__thread_fiber->ready, &fiber->me);
 
 	curr->status = FIBER_STATUS_READY;
 	ring_prepend(&__thread_fiber->ready, &curr->me);
-
-	acl_fiber_switch();
 #endif
+	acl_fiber_switch();
+	fiber->flag &= ~FIBER_F_SIGNALED;
 }
 
 int acl_fiber_signum(ACL_FIBER *fiber)

--- a/lib_fiber/c/src/fiber_io.c
+++ b/lib_fiber/c/src/fiber_io.c
@@ -402,7 +402,6 @@ static void read_callback(EVENT *ev, FILE_EVENT *fe)
 	if (fe->fiber_r->status != FIBER_STATUS_READY) {
 		acl_fiber_ready(fe->fiber_r);
 	}
-	__thread_fiber->io_count--;
 }
 
 /**
@@ -426,9 +425,10 @@ int fiber_wait_read(FILE_EVENT *fe)
 	}
 
 	fe->fiber_r->status = FIBER_STATUS_WAIT_READ;
-	__thread_fiber->io_count++;
+	fiber_io_inc();
 	SET_READWAIT(fe);
 	acl_fiber_switch();
+	fiber_io_dec();
 	return ret;
 }
 
@@ -444,7 +444,6 @@ static void write_callback(EVENT *ev, FILE_EVENT *fe)
 	if (fe->fiber_w->status != FIBER_STATUS_READY) {
 		acl_fiber_ready(fe->fiber_w);
 	}
-	__thread_fiber->io_count--;
 }
 
 int fiber_wait_write(FILE_EVENT *fe)
@@ -460,10 +459,10 @@ int fiber_wait_write(FILE_EVENT *fe)
 	}
 
 	fe->fiber_w->status = FIBER_STATUS_WAIT_WRITE;
-	__thread_fiber->io_count++;
+	fiber_io_inc();
 	SET_WRITEWAIT(fe);
 	acl_fiber_switch();
-
+	fiber_io_dec();
 	return ret;
 }
 


### PR DESCRIPTION
仅在linux下出现 (linux mint, gcc 9.4.0)

复现步骤: 
1. 使用mariadb-connector-c 3.1.16, 静态编译
2. mysql_init, mysql_real_connect, mysql_ping
3. 会在mysql_ping中死循环

原因: 
这个库会切换socket的block状态, 然后循环调用recv/poll以探测数据, 卡死在这里 (pvio_socket_read)
调试后发现是``poll``异常, fiber库替换了系统实现, 当超时触发``acl_fiber_signal``后会给fiber置``FIBER_F_SIGNALED``标志
导致后续调用``recv``时始终返回EAGAIN (11), 因为在``acl_fiber_read``中``acl_fiber_canceled``始终成立

解决方法:
所以在signal触发后, fiber switch回来后再把标志去掉

然后发现io count计数不正常, add read 后没有触发read callback, 也是因为上述原因没有触发回调
而io的计数是分散的, 所以改到了一起, 切换前count++切回来count--效果应该是一样的

此PR可能有对acl fiber理解不对的地方, 请作者考虑后再合并
