### PR TITLE
Fix bug: redis_client get_string not comsume ending \r\n on empty string

### DIFF
--- a/lib_acl_cpp/src/redis/redis_client.cpp
+++ b/lib_acl_cpp/src/redis/redis_client.cpp
@@ -246,7 +246,7 @@ redis_result* redis_client::get_string(socket_stream& conn, dbuf_pool* dbuf)
 	redis_result* rr = new(dbuf) redis_result(dbuf);
 	rr->set_type(REDIS_RESULT_STRING);
 	int len = atoi(sbuf.c_str());
-	if (len <= 0) {
+	if (len < 0) {
 		return rr;
 	}
 


### PR DESCRIPTION
Fix bug: redis_client get_string not comsume ending \r\n on empty string, which cause parse error when hgetall on key that contain such empty string.